### PR TITLE
Add support for guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
The strict version requirement is breaking some other dependencies, not allowing them to update. It would be nice if this can be release as soon as possible.