### PR TITLE
Add dependency on guzzle/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2 || ^7.0.0"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0.0",
+        "guzzlehttp/psr7": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
This package uses functions from `guzzle/psr7`, see #16. These functions break with `guzzle/psr7` version 2.x. As there was no explicit requirement defined, this package can now be installed side-by-side with psr7 2.x.

This PR does 2 things:

* Explicitly define the dependency (as there is one)
* Require at least `guzzle/psr7` 1.7. This doesn't break anything (you can update from <1.7 to 1.7 without issue). This is forward compatible with the changes in #16 (as the static API used in that PR and required as of 2.x was introduced in 1.7.0).