### PR TITLE
Fix incorrect license type in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "api"
     ],
     "homepage": "https://openapi-generator.tech",
-    "license": "unlicense",
+    "license": "MIT",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",


### PR DESCRIPTION
The composer.json file had unlicensed set, instead of the MIT license which the project is actually licensed under. This PR solves that.