### PR TITLE
Adds PHP declarative types on the signatures of ArrayAccess and JsonSerializable interface for PHP 8.1

### DIFF
--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -565,7 +565,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -577,7 +577,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -590,7 +590,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -606,7 +606,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -618,7 +618,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/AddressesList.php
+++ b/lib/Model/AddressesList.php
@@ -235,7 +235,7 @@ class AddressesList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class AddressesList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class AddressesList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class AddressesList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class AddressesList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ApplicantRequest.php
+++ b/lib/Model/ApplicantRequest.php
@@ -475,7 +475,7 @@ class ApplicantRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -487,7 +487,7 @@ class ApplicantRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -500,7 +500,7 @@ class ApplicantRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -516,7 +516,7 @@ class ApplicantRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -528,7 +528,7 @@ class ApplicantRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ApplicantResponse.php
+++ b/lib/Model/ApplicantResponse.php
@@ -595,7 +595,7 @@ class ApplicantResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -607,7 +607,7 @@ class ApplicantResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -620,7 +620,7 @@ class ApplicantResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -636,7 +636,7 @@ class ApplicantResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -648,7 +648,7 @@ class ApplicantResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ApplicantsList.php
+++ b/lib/Model/ApplicantsList.php
@@ -235,7 +235,7 @@ class ApplicantsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class ApplicantsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class ApplicantsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class ApplicantsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class ApplicantsList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/CheckRequest.php
+++ b/lib/Model/CheckRequest.php
@@ -565,7 +565,7 @@ class CheckRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -577,7 +577,7 @@ class CheckRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -590,7 +590,7 @@ class CheckRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -606,7 +606,7 @@ class CheckRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -618,7 +618,7 @@ class CheckRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/CheckResponse.php
+++ b/lib/Model/CheckResponse.php
@@ -655,7 +655,7 @@ class CheckResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -667,7 +667,7 @@ class CheckResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -680,7 +680,7 @@ class CheckResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -696,7 +696,7 @@ class CheckResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -708,7 +708,7 @@ class CheckResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ChecksList.php
+++ b/lib/Model/ChecksList.php
@@ -235,7 +235,7 @@ class ChecksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class ChecksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class ChecksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class ChecksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class ChecksList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/DocumentResponse.php
+++ b/lib/Model/DocumentResponse.php
@@ -535,7 +535,7 @@ class DocumentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -547,7 +547,7 @@ class DocumentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -560,7 +560,7 @@ class DocumentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -576,7 +576,7 @@ class DocumentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -588,7 +588,7 @@ class DocumentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/DocumentsList.php
+++ b/lib/Model/DocumentsList.php
@@ -235,7 +235,7 @@ class DocumentsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class DocumentsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class DocumentsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class DocumentsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class DocumentsList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/Error.php
+++ b/lib/Model/Error.php
@@ -235,7 +235,7 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ErrorProperties.php
+++ b/lib/Model/ErrorProperties.php
@@ -295,7 +295,7 @@ class ErrorProperties implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -307,7 +307,7 @@ class ErrorProperties implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -320,7 +320,7 @@ class ErrorProperties implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -336,7 +336,7 @@ class ErrorProperties implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -348,7 +348,7 @@ class ErrorProperties implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/IdNumber.php
+++ b/lib/Model/IdNumber.php
@@ -295,7 +295,7 @@ class IdNumber implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -307,7 +307,7 @@ class IdNumber implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -320,7 +320,7 @@ class IdNumber implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -336,7 +336,7 @@ class IdNumber implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -348,7 +348,7 @@ class IdNumber implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/LivePhotoResponse.php
+++ b/lib/Model/LivePhotoResponse.php
@@ -415,7 +415,7 @@ class LivePhotoResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -427,7 +427,7 @@ class LivePhotoResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -440,7 +440,7 @@ class LivePhotoResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -456,7 +456,7 @@ class LivePhotoResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -468,7 +468,7 @@ class LivePhotoResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/LivePhotosList.php
+++ b/lib/Model/LivePhotosList.php
@@ -235,7 +235,7 @@ class LivePhotosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class LivePhotosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class LivePhotosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class LivePhotosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class LivePhotosList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/LiveVideo.php
+++ b/lib/Model/LiveVideo.php
@@ -445,7 +445,7 @@ class LiveVideo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -457,7 +457,7 @@ class LiveVideo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -470,7 +470,7 @@ class LiveVideo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -486,7 +486,7 @@ class LiveVideo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -498,7 +498,7 @@ class LiveVideo implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/LiveVideosList.php
+++ b/lib/Model/LiveVideosList.php
@@ -235,7 +235,7 @@ class LiveVideosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class LiveVideosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class LiveVideosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class LiveVideosList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class LiveVideosList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/Location.php
+++ b/lib/Model/Location.php
@@ -265,7 +265,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -277,7 +277,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -290,7 +290,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +306,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -318,7 +318,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/Report.php
+++ b/lib/Model/Report.php
@@ -538,7 +538,7 @@ class Report implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -550,7 +550,7 @@ class Report implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -563,7 +563,7 @@ class Report implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -579,7 +579,7 @@ class Report implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -591,7 +591,7 @@ class Report implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ReportDocument.php
+++ b/lib/Model/ReportDocument.php
@@ -238,7 +238,7 @@ class ReportDocument implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -250,7 +250,7 @@ class ReportDocument implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -263,7 +263,7 @@ class ReportDocument implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -279,7 +279,7 @@ class ReportDocument implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -291,7 +291,7 @@ class ReportDocument implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/ReportsList.php
+++ b/lib/Model/ReportsList.php
@@ -235,7 +235,7 @@ class ReportsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class ReportsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class ReportsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class ReportsList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class ReportsList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/SdkTokenRequest.php
+++ b/lib/Model/SdkTokenRequest.php
@@ -325,7 +325,7 @@ class SdkTokenRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -337,7 +337,7 @@ class SdkTokenRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -350,7 +350,7 @@ class SdkTokenRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -366,7 +366,7 @@ class SdkTokenRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -378,7 +378,7 @@ class SdkTokenRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/SdkTokenResponse.php
+++ b/lib/Model/SdkTokenResponse.php
@@ -235,7 +235,7 @@ class SdkTokenResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class SdkTokenResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class SdkTokenResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class SdkTokenResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class SdkTokenResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/WebhookRequest.php
+++ b/lib/Model/WebhookRequest.php
@@ -328,7 +328,7 @@ class WebhookRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -340,7 +340,7 @@ class WebhookRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -353,7 +353,7 @@ class WebhookRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -369,7 +369,7 @@ class WebhookRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -381,7 +381,7 @@ class WebhookRequest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/WebhookResponse.php
+++ b/lib/Model/WebhookResponse.php
@@ -418,7 +418,7 @@ class WebhookResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -430,7 +430,7 @@ class WebhookResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -443,7 +443,7 @@ class WebhookResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -459,7 +459,7 @@ class WebhookResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -471,7 +471,7 @@ class WebhookResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }

--- a/lib/Model/WebhooksList.php
+++ b/lib/Model/WebhooksList.php
@@ -235,7 +235,7 @@ class WebhooksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset) : bool
     {
         return isset($this->container[$offset]);
     }
@@ -247,7 +247,7 @@ class WebhooksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset) : mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -260,7 +260,7 @@ class WebhooksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value) : void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +276,7 @@ class WebhooksList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset) : void
     {
         unset($this->container[$offset]);
     }
@@ -288,7 +288,7 @@ class WebhooksList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed 
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }


### PR DESCRIPTION
PHP 8.1 is now throwing **Deprecated** notices when any of it's interfaces are used and the types are not declared as they are in it's current interface definition.

https://github.com/onfido/api-php-client/issues/33
This issue was opened about 4 months ago. I was facing the same problem when I ran my unit test. When I looked into it, I found the simple solution and am sending it here. If you add this fix it will cause the **deprecated** notice to go away.

I tested with PHP 7.4 on my local and it doesn't seem to cause any problems on it either as this is not going to be enforced till PHP 9.0. 