### PR TITLE
Refresh onfido-php after onfido-openapi-spec update (4204f00)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -3,7 +3,7 @@
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
     "short_sha": "4204f00",
     "long_sha": "4204f00a2c7f0f5bd61da3b5442d8eb613418e9e",
-    "version": ""
+    "version": "v6.0.0"
   },
   "release": "v10.0.0"
 }

--- a/test/Resource/WorkflowRunsTest.php
+++ b/test/Resource/WorkflowRunsTest.php
@@ -58,7 +58,17 @@ class WorkflowRunsTest extends OnfidoTestCase
 
     public function testDownloadEvidenceFile(): void
     {
-        $file = self::$onfido->downloadSignedEvidenceFile($this->workflowRun->getId());
+        $getEvidenceFileFn = function($workflowRunId) {
+          return self::$onfido->downloadSignedEvidenceFile($workflowRunId);
+        };
+
+        $file = $this->repeatRequestUntilHttpCodeChanges(
+          $getEvidenceFileFn,
+          [$this->workflowRun->getId()],
+          15,
+          2
+        );
+
         $this->assertGreaterThan(0, $file->getSize());
     }
 
@@ -130,7 +140,9 @@ class WorkflowRunsTest extends OnfidoTestCase
 
         $file = $this->repeatRequestUntilHttpCodeChanges(
           $getEvidenceFolderFn,
-          [$workflowRunId]
+          [$workflowRunId],
+          15,
+          2
         );
 
         $this->assertGreaterThan(0, $file->getSize());


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@4204f00a2c7f0f5bd61da3b5442d8eb613418e9e (included)

Additional changes:
  - [Add retry logic with 30s timeout for evidence file downloads](https://github.com/onfido/onfido-php/pull/94/changes/a0beb9556beea91243ab9146072ceef3a5d32b87)