### PR TITLE
[CAT-2931] ci: add distributed lock for integration tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,10 +41,10 @@ jobs:
         id: should-run-integration-tests
         if: ${{ matrix.php-version == '8.3' &&
           github.repository_owner == 'onfido' }}
-        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
+        uses: onfido/onfido-actions/should-run-integration-tests@main
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@add-lock-action
+        uses: onfido/onfido-actions/lock/acquire@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
@@ -73,7 +73,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@add-lock-action
+        uses: onfido/onfido-actions/lock/release@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -46,7 +46,8 @@ jobs:
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
       - name: Test with API token auth
         if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
@@ -74,7 +75,8 @@ jobs:
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,12 +40,8 @@ jobs:
       - name: Should run integration tests
         id: should-run-integration-tests
         if: ${{ matrix.php-version == '8.3' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
+          github.repository_owner == 'onfido' }}
+        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "result=true" >> "$GITHUB_OUTPUT"
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@main
+        uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
       - name: Test with API token auth
@@ -76,7 +76,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@main
+        uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,13 +37,22 @@ jobs:
         uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           php_version: ${{ matrix.php-version }}
-      - name: Test with API token auth
+      - name: Should run integration tests
+        id: should-run-integration-tests
         if: ${{ matrix.php-version == '8.3' &&
           github.repository_owner == 'onfido' &&
           (github.event_name == 'pull_request' ||
            github.event_name == 'release' ||
            github.event_name == 'workflow_dispatch' ||
            github.event_name == 'schedule') }}
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+      - name: Acquire integration test lock
+        if: steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/acquire@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+      - name: Test with API token auth
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
           vendor/bin/phpunit
         env:
@@ -54,12 +63,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Test with OAuth client credentials auth
-        if: ${{ matrix.php-version == '8.3' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
           vendor/bin/phpunit
         env:
@@ -70,6 +74,11 @@ jobs:
           ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
+      - name: Release integration test lock
+        if: always() && steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/release@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevents integration tests from running in parallel across SDK repositories by using a distributed lock via [onfido-actions/lock](https://github.com/onfido/onfido-actions).

**Changes:**
- Add `should-run-integration-tests` action to determine when tests should run
- Acquire/release a cross-repo lock around integration tests